### PR TITLE
Add optional stack flag

### DIFF
--- a/cf/actions.go
+++ b/cf/actions.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 )
 
-func Push(name, directory string) error {
-	_, err := runCF("push", name, "-p", directory)
+func Push(name, directory, stack string) error {
+	_, err := runCF("push", name, "-p", directory, "-s", stack)
 	return err
 }
 

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ func main() {
 
 	pwd, err := os.Getwd()
 	mustNot("get CWD", err)
+	stack := flag.String("stack", "cflinuxfs2", "The stack to push the app to")
 	appDir := flag.String("app-dir", pwd, "The directory of the app to push")
 	dopplerAddress := flag.String("doppler-address", "", "doppler address")
 	var jsonOutput bool
@@ -56,7 +57,7 @@ func main() {
 	time.Sleep(time.Second * 5)
 
 	appName := fmt.Sprintf("benchme-%v", time.Now().Unix())
-	must("pushing app", cf.Push(appName, *appDir))
+	must("pushing app", cf.Push(appName, *appDir, *stack))
 	appGuid, err := cf.AppGuid(appName)
 	mustNot("getting app GUID", err)
 	must("deleting app", cf.Delete(appName))


### PR DESCRIPTION
This allows users to run `cfbench` with an optional `--stack` flag (that defaults to `cflinuxfs2`) to push apps to stacks other than the default in their CF foundation.

This will be helpful for the Garden Windows team as we try to get more metrics to compare our `windows2012R2` and `windows2016` stacks/Garden implementations.