### PR TITLE
UnixNano so concurrent cfbench apps dont collide

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,7 +56,7 @@ func main() {
 	log.Println("Waiting a few seconds to verify messages are being recorded")
 	time.Sleep(time.Second * 5)
 
-	appName := fmt.Sprintf("benchme-%v", time.Now().Unix())
+	appName := fmt.Sprintf("benchme-%v", time.Now().UnixNano())
 	must("pushing app", cf.Push(appName, *appDir, *stack))
 	appGuid, err := cf.AppGuid(appName)
 	mustNot("getting app GUID", err)


### PR DESCRIPTION
We've seen route collisions with concurrent Concourse tasks with the `time.Unix()` added to the app name. If we instead do `time.UnixNano()` it reduces the likelihood they will collide.