### PR TITLE
Make matching log messages more forgiving

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -3,6 +3,7 @@ package bench
 import (
 	"fmt"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/cloudfoundry/sonde-go/events"
@@ -104,12 +105,12 @@ func (p Phases) PopulateTimestamps(appGUID string, events []*events.Envelope) {
 				continue
 			}
 
-			logLine := logMsg.GetMessage()
+			logLine := strings.ToLower(string(logMsg.GetMessage()))
 			//fmt.Printf("%s/%v: [%s]\n", logMsg.GetSourceType(), logMsg.GetSourceInstance(), string(logLine))
 
-			if phase.StartMsg == string(logLine) {
+			if strings.Contains(logLine, strings.ToLower(phase.StartMsg)) {
 				phase.StartTimestamp = *logMsg.Timestamp
-			} else if phase.EndMsg == string(logLine) {
+			} else if strings.Contains(logLine, strings.ToLower(phase.EndMsg)) {
 				remainingOccurences--
 				if remainingOccurences == 0 {
 					phase.EndTimestamp = *logMsg.Timestamp

--- a/bench/bench_test.go
+++ b/bench/bench_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Phase", func() {
 				&Phase{
 					Name:             "Total",
 					StartMsg:         "start-message",
-					EndMsg:           "end-message",
+					EndMsg:           "End-Message",
 					ShortName:        "total",
 					SourceType:       "FOO",
 					EndMsgOccurences: 1,
@@ -33,12 +33,12 @@ var _ = Describe("Phase", func() {
 			}
 
 			msgs = []*events.Envelope{
-				createEnvelopeMsg("start-message", "123456", "FOO", 2000),
-				createEnvelopeMsg("end-message", "123456", "FOO", 2400),
+				createEnvelopeMsg("abc! start-message sdlfgjj", "123456", "FOO", 2000),
+				createEnvelopeMsg("end-messagesldkfjg lkj", "123456", "FOO", 2400),
 			}
 		})
 
-		It("finds the phases which match", func() {
+		It("finds the phases which match part of the message, ignoring case", func() {
 			phases.PopulateTimestamps("123456", msgs)
 			Expect(phases[0].StartTimestamp).To(Equal(int64(2000)))
 			Expect(phases[0].EndTimestamp).To(Equal(int64(2400)))
@@ -49,7 +49,6 @@ var _ = Describe("Phase", func() {
 			Expect(phases[0].StartTimestamp).To(Equal(int64(0)))
 			Expect(phases[0].EndTimestamp).To(Equal(int64(0)))
 		})
-
 	})
 
 	Context("filters by source type", func() {


### PR DESCRIPTION
Recent versions of diego-release output logs in a slightly different format with different capitalization and placement of cell/container guids. Instead of matching an exact string, we now match a case insensitive substring.